### PR TITLE
feat(api): add api containerization files

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+.github/
+.husky/
+.vscode/
+.turbo/
+docs/
+node_modules/
+.gitattributes
+.gitignore
+LICENSE
+README.md
+lint-staged.config.cjs
+sonar-project.properties

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,69 @@
+services:
+  api:
+    container_name: api
+    restart: on-failure
+    build:
+      context: .
+      dockerfile: services/api/Dockerfile
+    ports:
+      - "1323:1323"
+    environment:
+      GO_ENV: production
+      PORT: 1323
+      POSTGRES_URI: postgres://root:password@postgresdb:5432/postgres
+      SERVER_URL: http://localhost:1323
+      MINIO_ACCESS_KEY: minioadmin
+      MINIO_SECRET_KEY: minioadmin
+      MINIO_ENDPOINT_URL: minio:9000
+      MINIO_STORAGE_BUCKET: scripts
+    depends_on:
+      postgresdb:
+        condition: service_healthy
+      minio:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "curl", "-f", "http://localhost:1323/health", "||", "exit", "1"]
+      start_period: 30s
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      
+  postgresdb:
+    container_name: postgresdb
+    image: postgres:14-alpine
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: root
+      POSTGRES_PASSWORD: password
+    ports:
+      - "5432:5432"
+    healthcheck:
+      test: [ "CMD-SHELL", "pg_isready", "-U", "root", "-d", "postgres" ]
+      start_period: 20s
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  minio:
+    container_name: minio
+    image: quay.io/minio/minio:latest
+    restart: unless-stopped 
+    command: server /data --console-address ":9001"
+    ports:
+      - "9000:9000"
+      - "9001:9001" # Site proxy
+    environment:
+      MINIO_ROOT_USER: minioadmin
+      MINIO_ROOT_PASSWORD: minioadmin
+    volumes:
+      - minio_data:/data
+    healthcheck:
+      test: [ "CMD", "curl", "-f", "http://localhost:9000/minio/health/ready" ]
+      start_period: 20s
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+volumes:
+  minio_data:
+    driver: local

--- a/services/api/Dockerfile
+++ b/services/api/Dockerfile
@@ -1,0 +1,27 @@
+FROM golang:1.24-bookworm AS build
+
+WORKDIR /src
+
+COPY services/api/go.mod services/api/go.sum ./
+RUN go mod download
+
+COPY services/api/ .
+RUN CGO_ENABLED=0 GOOS=linux go build -o /api ./cmd/api
+
+
+FROM debian:bookworm-slim
+
+RUN apt-get update && apt-get install -y \
+  ca-certificates \
+  && rm -rf /tmp/* \
+  && rm -rf /var/lib/apt/lists/* \
+  && groupadd -r -g 1001 golang \
+  && useradd -r -u 1001 -g golang api
+
+COPY --from=build --chown=api:golang /api /usr/local/bin/api
+
+USER api
+
+EXPOSE 1323
+
+ENTRYPOINT ["api"]

--- a/services/api/Dockerfile
+++ b/services/api/Dockerfile
@@ -19,6 +19,7 @@ RUN apt-get update && apt-get install -y \
   && useradd -r -u 1001 -g golang api
 
 COPY --from=build --chown=api:golang /api /usr/local/bin/api
+RUN chmod 555 /usr/local/bin/api
 
 USER api
 

--- a/services/api/Dockerfile
+++ b/services/api/Dockerfile
@@ -13,6 +13,7 @@ FROM debian:bookworm-slim
 
 RUN apt-get update && apt-get install -y \
   ca-certificates \
+  curl \
   && rm -rf /tmp/* \
   && rm -rf /var/lib/apt/lists/* \
   && groupadd -r -g 1001 golang \

--- a/services/api/Dockerfile
+++ b/services/api/Dockerfile
@@ -6,7 +6,8 @@ COPY services/api/go.mod services/api/go.sum ./
 RUN go mod download
 
 COPY services/api/ .
-RUN CGO_ENABLED=0 GOOS=linux go build -o /api ./cmd/api
+RUN CGO_ENABLED=0 GOOS=linux go build -o /api ./cmd/api \
+  && chmod 555 /api
 
 
 FROM debian:bookworm-slim
@@ -20,7 +21,6 @@ RUN apt-get update && apt-get install -y \
   && useradd -r -u 1001 -g golang api
 
 COPY --from=build --chown=api:golang /api /usr/local/bin/api
-RUN chmod 555 /usr/local/bin/api
 
 USER api
 


### PR DESCRIPTION
This pull request introduces Docker support for the project, enabling local development and deployment using Docker Compose. It adds configuration files to build and run the API service, a PostgreSQL database, and a MinIO object storage service in containers, along with appropriate ignore rules for Docker builds.

**Docker and Containerization Setup:**

* Added a `.dockerignore` file to exclude unnecessary directories and files (such as `.github/`, `docs/`, and `node_modules/`) from Docker build context, reducing image size and build time.
* Created a multi-stage `services/api/Dockerfile` to build the Go API binary and assemble a minimal runtime image, improving build efficiency and security by using a non-root user.

**Docker Compose Configuration:**

* Added a `compose.yaml` file to orchestrate three services: the API (`api`), PostgreSQL (`postgresdb`), and MinIO (`minio`). This includes health checks, environment variables, port mappings, and volume setup for persistent MinIO storage.